### PR TITLE
Update QuizService.java

### DIFF
--- a/src/main/java/com/telusko/quizapp/service/QuizService.java
+++ b/src/main/java/com/telusko/quizapp/service/QuizService.java
@@ -55,12 +55,27 @@ public class QuizService {
         List<Question> questions = quiz.getQuestions();
         int right = 0;
         int i = 0;
-        for(Response response : responses){
-            if(response.getResponse().equals(questions.get(i).getRightAnswer()))
-                right++;
 
-            i++;
-        }
+      Map<Integer, Question> questionMap = new HashMap<>();
+	    for (Question question : questions) {
+	        questionMap.put(question.getId(), question);
+	    }
+
+	    // Iterate through the responses
+	    for (Response response : responses) {
+	        // Retrieve the corresponding question using the response's question ID
+	        Question question = questionMap.get(response.getId());
+	        if (question != null && response.getResponse().equals(question.getRightAnswer())) {
+	            right++; // Increment the correct response count
+	        }
+	    }
+
+        // for(Response response : responses){
+        //     if(response.getResponse().equals(questions.get(i).getRightAnswer()))
+        //         right++;
+
+        //     i++;
+        // }
         return new ResponseEntity<>(right, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
Changed calculateResult() method to calculate result in quizService.

Issue:
Previous method only worked if response list and questions list were in same order. What if response is suffled or list of questions fetched from database is not in order of respose then there answers won't match as we are matching them with index, not by id.

Solution:
Created a HashMap to store key as 'id' and value as 'question' object and store all questions in Map.

Now it became easy to fetch question by "response.getId" and compared both answers.

Now it will give right answer every time doesn't matter what is the sequence of lists.